### PR TITLE
Improve progress bar (ETA and Unicode-based rendering)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 julia = "1"

--- a/src/ProgressMeter/LICENSE.txt
+++ b/src/ProgressMeter/LICENSE.txt
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2013 Timothy E. Holy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/ProgressMeter/ProgressMeter.jl
+++ b/src/ProgressMeter/ProgressMeter.jl
@@ -1,0 +1,114 @@
+module ProgressMeter
+
+using Printf: @printf, @sprintf
+
+"""
+Holds the five characters that will be used to generate the progress bar.
+"""
+mutable struct BarGlyphs
+    leftend::Char
+    fill::Char
+    front::Union{Vector{Char}, Char}
+    empty::Char
+    rightend::Char
+end
+
+BarGlyphs() = BarGlyphs(
+    '|',
+    '█',
+    Sys.iswindows() ? '█' : ['▏', '▎', '▍', '▌', '▋', '▊', '▉'],
+    ' ',
+    '|',
+)
+
+struct ProgressBar
+    barglyphs::BarGlyphs
+    tfirst::Float64
+end
+
+ProgressBar(barglyphs = BarGlyphs()) = ProgressBar(barglyphs, time())
+
+"""
+    printprogress(io::IO, p::ProgressBar, desc, progress::Real)
+
+Print progress bar to `io` with setting `p`.
+
+# Arguments
+- `io::IO`
+- `p::ProgressBar`
+- `desc`: description to be printed at left side of progress bar.
+- `progress::Real`: a number between 0 and 1 or a `NaN`.
+"""
+function printprogress(io::IO, p::ProgressBar, desc, progress::Real)
+    t = time()
+    percentage_complete = 100.0 * (isnan(progress) ? 0.0 : progress)
+
+    #...length of percentage and ETA string with days is 29 characters
+    barlen = max(0, displaysize(io)[2] - (length(desc) + 29))
+
+    if progress >= 1
+        bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
+        dur = durationstring(t - p.tfirst)
+        @printf io "%s%3u%%%s Time: %s" desc round(Int, percentage_complete) bar dur
+        return
+    end
+
+    bar = barstring(barlen, percentage_complete, barglyphs=p.barglyphs)
+    elapsed_time = t - p.tfirst
+    est_total_time = 100 * elapsed_time / percentage_complete
+    if 0 <= est_total_time <= typemax(Int)
+        eta_sec = round(Int, est_total_time - elapsed_time)
+        eta = durationstring(eta_sec)
+    else
+        eta = "N/A"
+    end
+    @printf io "%s%3u%%%s  ETA: %s" desc round(Int, percentage_complete) bar eta
+    return
+end
+
+function compute_front(barglyphs::BarGlyphs, frac_solid::AbstractFloat)
+    barglyphs.front isa Char && return barglyphs.front
+    idx = round(Int, frac_solid * (length(barglyphs.front) + 1))
+    return idx > length(barglyphs.front) ? barglyphs.fill :
+           idx == 0 ? barglyphs.empty :
+           barglyphs.front[idx]
+end
+
+function barstring(barlen, percentage_complete; barglyphs)
+    bar = ""
+    if barlen>0
+        if percentage_complete == 100 # if we're done, don't use the "front" character
+            bar = string(barglyphs.leftend, repeat(string(barglyphs.fill), barlen), barglyphs.rightend)
+        else
+            n_bars = barlen * percentage_complete / 100
+            nsolid = trunc(Int, n_bars)
+            frac_solid = n_bars - nsolid
+            nempty = barlen - nsolid - 1
+            bar = string(barglyphs.leftend,
+                         repeat(string(barglyphs.fill), max(0,nsolid)),
+                         compute_front(barglyphs, frac_solid),
+                         repeat(string(barglyphs.empty), max(0, nempty)),
+                         barglyphs.rightend)
+        end
+    end
+    bar
+end
+
+function durationstring(nsec)
+    days = div(nsec, 60*60*24)
+    r = nsec - 60*60*24*days
+    hours = div(r,60*60)
+    r = r - 60*60*hours
+    minutes = div(r, 60)
+    seconds = floor(r - 60*minutes)
+
+    hhmmss = @sprintf "%u:%02u:%02u" hours minutes seconds
+    if days>9
+        return @sprintf "%.2f days" nsec/(60*60*24)
+    elseif days>0
+        return @sprintf "%u days, %s" days hhmmss
+    end
+    hhmmss
+end
+
+end

--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -125,7 +125,7 @@ function handle_progress(logger, message, id, progress)
             printprogress,
             bar,
             message,
-            progress;
+            progress == "done" ? 1.0 : progress;
             context = :displaysize => displaysize(logger.stream),
         )
 

--- a/src/TerminalLoggers.jl
+++ b/src/TerminalLoggers.jl
@@ -7,12 +7,13 @@ using Logging:
 import Logging:
     handle_message, shouldlog, min_enabled_level, catch_exceptions
 
-using ProgressMeter:
-    Progress, update!
-
 export TerminalLogger
 
 const ProgressLevel = LogLevel(-1)
+
+include("ProgressMeter/ProgressMeter.jl")
+using .ProgressMeter:
+    ProgressBar, printprogress
 
 include("StickyMessages.jl")
 include("TerminalLogger.jl")

--- a/src/TerminalLoggers.jl
+++ b/src/TerminalLoggers.jl
@@ -7,7 +7,12 @@ using Logging:
 import Logging:
     handle_message, shouldlog, min_enabled_level, catch_exceptions
 
+using ProgressMeter:
+    Progress, update!
+
 export TerminalLogger
+
+const ProgressLevel = LogLevel(-1)
 
 include("StickyMessages.jl")
 include("TerminalLogger.jl")

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -230,5 +230,5 @@ import TerminalLoggers.default_metafmt
     ⊏(s, re) = match(re, s) !== nothing
 
     @test genmsg("", progress=0.1, width=60) ⊏
-    r"Progress:  10%\|██▏                  \|  ETA: 0:00:[0-9][0-9]"
+    r"Progress:  10%\|██.                  \|  ETA: 0:00:[0-9][0-9]"
 end

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -225,4 +225,7 @@ import TerminalLoggers.default_metafmt
     \e[36m\e[1m│ \e[22m\e[39mline2
     \e[36m\e[1m└ \e[22m\e[39m\e[90mSUFFIX\e[39m
     """
+
+   @test genmsg("", progress=0.1, width=60) ==
+   "Progress:  10%|██▏                  |  ETA: 0:00:00"
 end

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -226,6 +226,9 @@ import TerminalLoggers.default_metafmt
     \e[36m\e[1m└ \e[22m\e[39m\e[90mSUFFIX\e[39m
     """
 
-   @test genmsg("", progress=0.1, width=60) ==
-   "Progress:  10%|██▏                  |  ETA: 0:00:00"
+    @test match(
+        r"Progress:  10%\|██▏                  \|  ETA: 0:00:[0-9][0-9]",
+        genmsg("", progress=0.1, width=60),
+    ) !== nothing
+
 end

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -251,8 +251,8 @@ import TerminalLoggers.default_metafmt
 
     @test genmsg("", progress=0.1, width=60) ⊏
     r"Progress:  10%\|██.                  \|  ETA: 0:00:[0-9][0-9]"
-    @test genmsg("", progress=NaN, width=60) ==
-    "Progress:   0%|                     |  ETA: N/A"
+    @test genmsg("", progress=NaN, width=60) ⊏
+    r"Progress:   0%|.                    |  ETA: N/A"
     @test genmsg("", progress=1.0, width=60) == ""
     @test genmsg("", progress="done", width=60) == ""
     @test genmsgs([("", (progress = 0.1,)), ("", (progress = 1.0,))], width = 60)[end] ⊏

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -42,10 +42,10 @@ import TerminalLoggers.default_metafmt
     end
 
     # Log formatting
-    function genmsg(message; level=Info, _module=Main,
-                    file="some/path.jl", line=101, color=false, width=75,
-                    meta_formatter=dummy_metafmt, show_limited=true,
-                    right_justify=0, kws...)
+    function genmsgs(events; level=Info, _module=Main,
+                     file="some/path.jl", line=101, color=false, width=75,
+                     meta_formatter=dummy_metafmt, show_limited=true,
+                     right_justify=0)
         buf = IOBuffer()
         io = IOContext(buf, :displaysize=>(30,width), :color=>color)
         logger = TerminalLogger(io, Debug,
@@ -53,9 +53,29 @@ import TerminalLoggers.default_metafmt
                                 show_limited=show_limited,
                                 right_justify=right_justify)
         prev_have_color = Base.have_color
-        handle_message(logger, level, message, _module, :a_group, :an_id,
-                       file, line; kws...)
-        String(take!(buf))
+        return map(events) do (message, kws)
+            handle_message(logger, level, message, _module, :a_group, :an_id,
+                           file, line; kws...)
+            String(take!(buf))
+        end
+    end
+    function genmsg(message; kwargs...)
+        kws = Dict(kwargs)
+        logconfig = Dict(
+            k => pop!(kws, k)
+            for k in [
+                :level,
+                :_module,
+                :file,
+                :line,
+                :color,
+                :width,
+                :meta_formatter,
+                :show_limited,
+                :right_justify,
+            ] if haskey(kws, k)
+        )
+        return genmsgs([(message, kws)]; logconfig...)[1]
     end
 
     # Basic tests for the default setup
@@ -231,4 +251,12 @@ import TerminalLoggers.default_metafmt
 
     @test genmsg("", progress=0.1, width=60) ⊏
     r"Progress:  10%\|██.                  \|  ETA: 0:00:[0-9][0-9]"
+    @test genmsg("", progress=NaN, width=60) ==
+    "Progress:   0%|                     |  ETA: N/A"
+    @test genmsg("", progress=1.0, width=60) == ""
+    @test genmsg("", progress="done", width=60) == ""
+    @test genmsgs([("", (progress = 0.1,)), ("", (progress = 1.0,))], width = 60)[end] ⊏
+    r"Progress: 100%|█████████████████████| Time: 0:00:[0-9][0-9]"
+    @test genmsgs([("", (progress = 0.1,)), ("", (progress = "done",))], width = 60)[end] ⊏
+    r"Progress: 100%|█████████████████████| Time: 0:00:[0-9][0-9]"
 end

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -226,9 +226,9 @@ import TerminalLoggers.default_metafmt
     \e[36m\e[1m└ \e[22m\e[39m\e[90mSUFFIX\e[39m
     """
 
-    @test match(
-        r"Progress:  10%\|██▏                  \|  ETA: 0:00:[0-9][0-9]",
-        genmsg("", progress=0.1, width=60),
-    ) !== nothing
+    # Using infix operator so that `@test` prints lhs and rhs when failed:
+    ⊏(s, re) = match(re, s) !== nothing
 
+    @test genmsg("", progress=0.1, width=60) ⊏
+    r"Progress:  10%\|██▏                  \|  ETA: 0:00:[0-9][0-9]"
 end

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -196,7 +196,7 @@ import TerminalLoggers.default_metafmt
         """,
         # EOL hack to work around git whitespace errors
         # VERSION dependence due to JuliaLang/julia#33339
-        (VERSION <= v"1.3" ? "EOL" : "       EOL")=>""
+        (VERSION < v"1.4-" ? "EOL" : "       EOL")=>""
         )
         # Limiting the amount which is printed
         @test genmsg("msg", a=fill(1.00001, 10,10), show_limited=false) ==


### PR DESCRIPTION
This PR implements ETA for progress bars. close #3.  <strike>It is a slightly hacky solution to use ProgressMeter.jl for generating a "smoother" progress bar and also let it compute and format ETA.  At some point, we may want to vendor ProgressMeter.jl or write our own functions to do this.  But I think this is a good start for now.</strike>