### PR TITLE
Fix StickyMessages for non-ASCII messages

### DIFF
--- a/src/StickyMessages.jl
+++ b/src/StickyMessages.jl
@@ -71,7 +71,7 @@ function showsticky(io, prev_nlines, messages)
         for i = 1:length(messages)-1
             write(iob, messages[i][2])
         end
-        write(iob, messages[end][2][1:end-1])
+        write(iob, chop(messages[end][2]))
     end
     # TODO: Ideally we'd query the terminal for the line it was on before doing
     # all this and restore it if it's not in the new non-scrollable region.

--- a/test/StickyMessages.jl
+++ b/test/StickyMessages.jl
@@ -35,4 +35,8 @@ end
                                 "\e[20;1H\e[J\e[1;20r\e[19;1H"
     pop!(stickies, :b)
     @test String(take!(buf)) == ""
+
+    push!(stickies, :a=>"αβγ\n")
+    @test String(take!(buf)) ==  #scroll    #csr    #pos   #msg #pos
+                                "\e[20;1H\n\e[1;19r\e[20;1Hαβγ\e[19;1H"
 end


### PR DESCRIPTION
Without this PR:

```julia
julia> with_logger(TerminalLogger()) do
           @info "αβγ" _id=:dummy sticky=true
       end
┌ Error: Exception while generating log record in module Main at REPL[11]:2
│   exception =
│    StringIndexError("\e[36m\e[1m[ \e[22m\e[39m\e[36m\e[1mInfo: \e[22m\e[39mαβγ\n", 52)
│    Stacktrace:
│     [1] string_index_err(::String, ::Int64) at ./strings/string.jl:12
│     [2] getindex at ./strings/string.jl:249 [inlined]
│     [3] showsticky(::Base.TTY, ::Int64, ::Array{Pair{Any,String},1}) at /home/takafumi/.julia/dev/TerminalLoggers/src/StickyMessages.jl:74
│     [4] push!(::StickyMessages, ::Pair{Symbol,String}) at /home/takafumi/.julia/dev/TerminalLoggers/src/StickyMessages.jl:98
│     [5] handle_message(::TerminalLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::String, ::Symbol, ::String, ::Int64; maxlog::Nothing, progress::Nothing, sticky::Bool, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/takafumi/.julia/dev/TerminalLoggers/src/TerminalLogger.jl:182
│     [6] macro expansion at ./logging.jl:321 [inlined]
│     [7] (::var"#39#40")() at ./REPL[11]:2
│     [8] with_logstate(::var"#39#40", ::Base.CoreLogging.LogState) at ./logging.jl:396
│     [9] with_logger(::Function, ::TerminalLogger) at ./logging.jl:503
│     [10] top-level scope at REPL[11]:1
│     [11] eval(::Module, ::Any) at ./boot.jl:331
│     [12] eval_user_input(::Any, ::REPL.REPLBackend) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
│     [13] run_backend(::REPL.REPLBackend) at /home/takafumi/.julia/packages/Revise/439di/src/Revise.jl:975
│     [14] (::Revise.var"#80#82"{REPL.REPLBackend})() at ./task.jl:333
└ @ Main REPL[11]:2
```