### PR TITLE
Remove "This file is a part of Julia"

### DIFF
--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 import TerminalLoggers.default_metafmt
 
 @noinline func1() = backtrace()


### PR DESCRIPTION
Hopefully this is the last one :)

On `master`:

```console
$ git grep "This file is a part of Julia"
test/TerminalLogger.jl:# This file is a part of Julia. License is MIT: https://julialang.org/license
```
