### PR TITLE
Colorize progress bars

### DIFF
--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -131,8 +131,12 @@ function handle_progress(logger, message, id, progress)
 
         if progress == "done" || progress >= 1
             pop!(logger.sticky_messages, id)
-            println(logger.stream, bartxt)
+            printstyled(logger.stream, bartxt; color=:light_black)
+            println(logger.stream)
         else
+            bartxt = sprint(context = logger.stream) do io
+                printstyled(io, bartxt; color=:green)
+            end
             push!(logger.sticky_messages, id => bartxt)
         end
     finally


### PR DESCRIPTION
I suggest using green for active progress bars and gray for completed progress bars. ATM, we don't use any color.

Example (with https://github.com/JuliaCI/BenchmarkTools.jl/pull/153):

![Peek 2020-01-25 22-43](https://user-images.githubusercontent.com/29282/73131669-4ad78680-3fc4-11ea-8cdc-e2581494eedf.gif)
