### PR TITLE
Markdown formatting for AbstractString log messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"


### PR DESCRIPTION
Fixes #16.

As suggested there, I'm now using `show(io, MIME"text/plain"(), message)` by default (except for strings, which go through `Markdown.parse()` first. With that in mind it might be sensible to tweak the API requirements for `message` again, revisiting whether `show` or `string` are used.