### PR TITLE
small fixes for fast-math mode

### DIFF
--- a/src/ProgressBar.jl
+++ b/src/ProgressBar.jl
@@ -24,13 +24,6 @@ function eta_seconds(bar)
     return total - (time() - bar.tfirst)
 end
 
-# issue #31: isnothing require Julia 1.1
-# copy-over from
-# https://github.com/JuliaLang/julia/blob/0413ef0e4de83b41b637ba02cc63314da45fe56b/base/some.jl
-if !isdefined(Base, :isnothing)
-    isnothing(::Any) = false
-    isnothing(::Nothing) = true
-end
 
 function printprogress(io::IO, bar::ProgressBar)
     if bar.name == ""

--- a/src/ProgressBar.jl
+++ b/src/ProgressBar.jl
@@ -43,7 +43,7 @@ function printprogress(io::IO, bar::ProgressBar)
         bar.barglyphs,
         bar.tfirst,
         desc,
-        something(bar.fraction, NaN),
+        bar.fraction,
         eta_seconds(bar),
     )
 end

--- a/src/ProgressBar.jl
+++ b/src/ProgressBar.jl
@@ -24,6 +24,14 @@ function eta_seconds(bar)
     return total - (time() - bar.tfirst)
 end
 
+# issue #31: isnothing require Julia 1.1
+# copy-over from
+# https://github.com/JuliaLang/julia/blob/0413ef0e4de83b41b637ba02cc63314da45fe56b/base/some.jl
+if !isdefined(Base, :isnothing)
+    isnothing(::Any) = false
+    isnothing(::Nothing) = true
+end
+
 function printprogress(io::IO, bar::ProgressBar)
     if bar.name == ""
         desc = "Progress: "

--- a/src/ProgressMeter/ProgressMeter.jl
+++ b/src/ProgressMeter/ProgressMeter.jl
@@ -22,7 +22,7 @@ BarGlyphs() = BarGlyphs(
 )
 
 """
-    printprogress(io::IO, barglyphs::BarGlyphs, tfirst::Float64, desc, progress::Union{Float64, Nothing})
+    printprogress(io::IO, barglyphs::BarGlyphs, tfirst::Float64, desc, progress, eta_seconds::Real)
 
 Print progress bar to `io`.
 
@@ -31,7 +31,7 @@ Print progress bar to `io`.
 - `barglyphs::BarGlyphs`
 - `tfirst::Float64`
 - `desc`: description to be printed at left side of progress bar.
-- `progress::Union{Float64, Nothing}`: a number between 0 and 1 or `nothing`.
+- `progress`: a number between 0 and 1 or `nothing`.
 - `eta_seconds::Real`: ETA in seconds
 """
 function printprogress(
@@ -39,7 +39,7 @@ function printprogress(
     barglyphs::BarGlyphs,
     tfirst::Float64,
     desc,
-    progress::Union{Float64, Nothing},
+    progress,
     eta_seconds::Real,
 )
     t = time()

--- a/src/ProgressMeter/ProgressMeter.jl
+++ b/src/ProgressMeter/ProgressMeter.jl
@@ -39,16 +39,16 @@ function printprogress(
     barglyphs::BarGlyphs,
     tfirst::Float64,
     desc,
-    progress::Real,
+    progress::Union{Float64,Nothing},
     eta_seconds::Real,
 )
     t = time()
-    percentage_complete = 100.0 * (isnan(progress) ? 0.0 : progress)
+    percentage_complete = 100.0 * (isnothing(progress) || isnan(progress) ? 0.0 : progress)
 
     #...length of percentage and ETA string with days is 29 characters
     barlen = max(0, displaysize(io)[2] - (length(desc) + 29))
 
-    if progress >= 1
+    if !isnothing(progress) && progress >= 1
         bar = barstring(barlen, percentage_complete, barglyphs=barglyphs)
         dur = durationstring(t - tfirst)
         @printf io "%s%3u%%%s Time: %s" desc round(Int, percentage_complete) bar dur

--- a/src/ProgressMeter/ProgressMeter.jl
+++ b/src/ProgressMeter/ProgressMeter.jl
@@ -111,4 +111,12 @@ function durationstring(nsec)
     hhmmss
 end
 
+# issue #31: isnothing require Julia 1.1
+# copy-over from
+# https://github.com/JuliaLang/julia/blob/0413ef0e4de83b41b637ba02cc63314da45fe56b/base/some.jl
+if !isdefined(Base, :isnothing)
+    isnothing(::Any) = false
+    isnothing(::Nothing) = true
+end
+
 end

--- a/src/ProgressMeter/ProgressMeter.jl
+++ b/src/ProgressMeter/ProgressMeter.jl
@@ -22,7 +22,7 @@ BarGlyphs() = BarGlyphs(
 )
 
 """
-    printprogress(io::IO, barglyphs::BarGlyphs, tfirst::Float64, desc, progress::Real)
+    printprogress(io::IO, barglyphs::BarGlyphs, tfirst::Float64, desc, progress::Union{Float64, Nothing})
 
 Print progress bar to `io`.
 
@@ -31,7 +31,7 @@ Print progress bar to `io`.
 - `barglyphs::BarGlyphs`
 - `tfirst::Float64`
 - `desc`: description to be printed at left side of progress bar.
-- `progress::Real`: a number between 0 and 1 or a `NaN`.
+- `progress::Union{Float64, Nothing}`: a number between 0 and 1 or `nothing`.
 - `eta_seconds::Real`: ETA in seconds
 """
 function printprogress(
@@ -39,7 +39,7 @@ function printprogress(
     barglyphs::BarGlyphs,
     tfirst::Float64,
     desc,
-    progress::Union{Float64,Nothing},
+    progress::Union{Float64, Nothing},
     eta_seconds::Real,
 )
     t = time()


### PR DESCRIPTION
As per the suggestion in https://github.com/c42f/TerminalLoggers.jl/issues/31, let progress be nothing since fast-math mode breaks NaN checks. Goes with https://github.com/JunoLab/ProgressLogging.jl/pull/30