### PR TITLE
Support printing of exception stacks from Base.catch_stack()

### DIFF
--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -141,17 +141,22 @@ end
 # Formatting of values in key value pairs
 function showvalue(io, key, msg)
     if key === :exception && msg isa Vector && length(msg) > 1 && msg[1] isa Tuple{Exception,Any}
-        # Ugly code path to support passing exception=Base.catch_stack()
-        # We don't have a useful "Exception Stack" type to look for here until
-        # https://github.com/JuliaLang/julia/pull/29901 gets unstuck.
-        Base.show_exception_stack(io, msg)
+        if VERSION >= v"1.2"
+            # Ugly code path to support passing exception=Base.catch_stack() We
+            # don't have a useful "Exception Stack" type to look for here until
+            # https://github.com/JuliaLang/julia/pull/29901 gets unstuck.
+            Base.show_exception_stack(io, msg)
+        else
+            # v1.0 and 1.1 don't have Base.show_exception_stack
+            show(io, "text/plain", msg)
+        end
     else
         show(io, "text/plain", msg)
     end
 end
 function showvalue(io, key, e::Tuple{Exception,Any})
     ex,bt = e
-    showerror(io, ex, bt; backtrace = bt!=nothing)
+    showerror(io, ex, bt; backtrace = bt!==nothing)
 end
 showvalue(io, key, ex::Exception) = showerror(io, ex)
 

--- a/src/TerminalLogger.jl
+++ b/src/TerminalLogger.jl
@@ -139,12 +139,21 @@ function format_message(message::AbstractString, prefix_width, io_context)
 end
 
 # Formatting of values in key value pairs
-showvalue(io, msg) = show(io, "text/plain", msg)
-function showvalue(io, e::Tuple{Exception,Any})
+function showvalue(io, key, msg)
+    if key === :exception && msg isa Vector && length(msg) > 1 && msg[1] isa Tuple{Exception,Any}
+        # Ugly code path to support passing exception=Base.catch_stack()
+        # We don't have a useful "Exception Stack" type to look for here until
+        # https://github.com/JuliaLang/julia/pull/29901 gets unstuck.
+        Base.show_exception_stack(io, msg)
+    else
+        show(io, "text/plain", msg)
+    end
+end
+function showvalue(io, key, e::Tuple{Exception,Any})
     ex,bt = e
     showerror(io, ex, bt; backtrace = bt!=nothing)
 end
-showvalue(io, ex::Exception) = showerror(io, ex)
+showvalue(io, key, ex::Exception) = showerror(io, ex)
 
 # Generate a text representation of all key value pairs, split into lines with
 # per-line indentation as an integer.
@@ -155,7 +164,7 @@ function format_key_value_pairs(kwargs, io_context)
     rows_per_value = max(1, dsize[1]÷(length(kwargs)+1))
     valio = IOContext(valbuf, IOContext(io_context, :displaysize=>(rows_per_value,dsize[2]-3)))
     for (key,val) in kwargs
-        showvalue(valio, val)
+        showvalue(valio, key, val)
         vallines = split(String(take!(valbuf)), '\n')
         if length(vallines) == 1
             push!(msglines, (2,SubString("$key = $(vallines[1])")))

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -196,16 +196,19 @@ end
     │     [1] func1() at""")
 
     # Exception stacks
-    excstack = try
-        error("Root cause")
-    catch
-        try
-            error("An exception")
+    if VERSION >= v"1.2"
+        excstack = try
+            error("Root cause")
         catch
-            Base.catch_stack()
+            try
+                error("An exception")
+            catch
+                Base.catch_stack()
+            end
         end
+        @test occursin(r"An exception.*Stacktrace.*caused by.*Root cause.*Stacktrace"s,
+                       genmsg("msg", exception=excstack))
     end
-    @test occursin(r"An exception.*Stacktrace.*caused by.*Root cause.*Stacktrace"s, genmsg("msg", exception=excstack))
 
     @testset "Limiting large data structures" begin
         @test genmsg("msg", a=fill(1.00001, 100,100), b=fill(2.00002, 10,10)) ==

--- a/test/TerminalLogger.jl
+++ b/test/TerminalLogger.jl
@@ -195,6 +195,17 @@ end
     │    Stacktrace:
     │     [1] func1() at""")
 
+    # Exception stacks
+    excstack = try
+        error("Root cause")
+    catch
+        try
+            error("An exception")
+        catch
+            Base.catch_stack()
+        end
+    end
+    @test occursin(r"An exception.*Stacktrace.*caused by.*Root cause.*Stacktrace"s, genmsg("msg", exception=excstack))
 
     @testset "Limiting large data structures" begin
         @test genmsg("msg", a=fill(1.00001, 100,100), b=fill(2.00002, 10,10)) ==


### PR DESCRIPTION
A bit ugly, but hard to do better, due to https://github.com/JuliaLang/julia/pull/29901 getting stuck in review (might be time to un-stick it! But in any case that wouldn't be in Base until 1.6)