### PR TITLE
enable StickyMessages ansi_codes on Windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TerminalLoggers"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 authors = ["Chris Foster <chris42f@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,10 +72,8 @@ end
 ```
 
 !!! note
-    Rendering progress bars separately doesn't yet work on windows due to
-    limitations of the windows console and its interaction with libuv.
-    We expect this will eventually be solved with some combination of libuv
-    updates and the new windows terminal.
+    On Windows, rendering progress bars requires julia 1.5.3 or later,
+    and scrolling works best on a modern terminal like Windows Terminal.
 
 You can also use the older progress logging API with the `progress=fraction`
 key value pair. This is simpler but has some downsides such as not interacting

--- a/src/StickyMessages.jl
+++ b/src/StickyMessages.jl
@@ -1,5 +1,6 @@
 """
-    StickyMessages(io::IO; ansi_codes=io isa Base.TTY && !Sys.iswindows())
+    StickyMessages(io::IO; ansi_codes=io isa Base.TTY && 
+                   (!Sys.iswindows() || VERSION >= v"1.5.3"))
 
 A `StickyMessages` type manages the display of a set of persistent "sticky"
 messages in a terminal. That is, messages which are not part of the normal
@@ -19,11 +20,8 @@ mutable struct StickyMessages
 end
 
 function StickyMessages(io::IO; ansi_codes=io isa Base.TTY &&
-        # Give up on Windows for now, as libuv doesn't recognize the scroll region code.
-        # Will need to be fixed in libuv and thence julia, but first libuv PR 1884 should merge. See
-        # https://github.com/libuv/libuv/pull/1884
-        # https://github.com/JuliaLang/libuv/commit/ed3700c849289ed01fe04273a7bf865340b2bd7e
-                                    !Sys.iswindows())
+        # scroll region code on Windows only works with recent libuv, present in 1.5.3+
+        (!Sys.iswindows() || VERSION >= v"1.5.3"))
     sticky = StickyMessages(io, ansi_codes, Vector{Pair{Any,String}}())
     # Ensure we clean up the terminal
     finalizer(sticky) do sticky


### PR DESCRIPTION
This now works due to new libuv patches landing in recent julia versions.

Fixes #28